### PR TITLE
Remove mention of Open Innovation Tournament

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,7 +321,7 @@ footer {
         
         <div class="profile-text">
         <p>
-        I specialize in breaking down complex problems to build better solutions. My experience spans from the <a href="http://innovationphilly.com" target="_blank">Philadelphia Open Innovation Tournament</a> to guiding executive teams through new technology adoption. I transform ambitious concepts into actionable strategies.
+        I specialize in breaking down complex problems to build better solutions. My experience spans from guiding executive teams through new technology adoption to transforming ambitious concepts into actionable strategies.
         </p>
         <p class="highlight-text">
         I help clients gain fresh insights and practical tools to overcome their most significant hurdles.


### PR DESCRIPTION
Removes the mention of the Philadelphia Open Innovation Tournament from the personal summary on the main page.