### PR TITLE
Reorder bookmarks in bookmarks.html

### DIFF
--- a/bookmarks.html
+++ b/bookmarks.html
@@ -14,9 +14,9 @@
 <meta content="#000000" name="theme-color"/>
 <link rel="stylesheet" href="shared.css?v=5">
 <script>
-  window.APP_CATEGORY_ORDER = ['news', 'games', 'listen', 'health'];
+  window.APP_CATEGORY_ORDER = ['listen', 'games', 'news', 'health'];
   window.APP_CUSTOM_ORDER = {
-    'news': ['the economist', 'nyt', 'x', 'polymarket'],
+    'news': ['the economist', 'x', 'nyt', 'polymarket'],
     'games': ['games'],
     'listen': ['spotify', 'classical', 'kobo', 'libby'],
     'health': ['oura ring', 'clublocker', 'solidcore']


### PR DESCRIPTION
User requested to reorder bookmarks in bookmarks.html, specifically: spotify/listen on top, followed by games, economist & X (news), and health.

Changed `window.APP_CATEGORY_ORDER` to achieve the main category reordering, and adjusted the internal order of the `news` category in `window.APP_CUSTOM_ORDER` to ensure `the economist` and `x` are prioritized within that list.

---
*PR created automatically by Jules for task [15613773391120094289](https://jules.google.com/task/15613773391120094289) started by @bradflaugher*