### PR TITLE
Update bookmarks NYTimes card

### DIFF
--- a/bookmarks.html
+++ b/bookmarks.html
@@ -12,15 +12,14 @@
 <meta content="black-translucent" name="apple-mobile-web-app-status-bar-style"/>
 <meta content="Bookmarks" name="apple-mobile-web-app-title"/>
 <meta content="#000000" name="theme-color"/>
-<link rel="stylesheet" href="shared.css?v=5">
+<link rel="stylesheet" href="shared.css?v=6">
 <script>
   var isMobile = window.matchMedia("(max-width: 600px)").matches || /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
   window.APP_CATEGORY_ORDER = isMobile
-    ? ['listen', 'news', 'games', 'health']
-    : ['listen', 'games', 'news', 'health'];
+    ? ['listen', 'news', 'health']
+    : ['listen', 'news', 'health'];
   window.APP_CUSTOM_ORDER = {
-    'news': ['the economist', 'x', 'nyt', 'polymarket'],
-    'games': ['games'],
+    'news': ['the economist', 'x', 'nytimes', 'polymarket'],
     'listen': ['spotify', 'classical', 'kobo', 'libby'],
     'health': ['oura ring', 'clublocker', 'solidcore']
   };
@@ -63,7 +62,7 @@
 <div class="bookmark-item" data-category="listen" data-ctx="personal"><a class="main-link" data-app-url="dewey-oauth://" href="#"><svg aria-hidden="true" class="ctx-icon" fill="currentColor" stroke="none" viewBox="0 0 24 24"><circle cx="12" cy="6.5" r="5.5"/><path d="M14.5 3l.8-2 .7 2.5-.6.8z"/><path d="M12 13c-4.5 0-8 1.5-9.5 3.5-.5.7-.5 1.2-.5 1.5v1c0 .6.4 1 1 1h3.5L12 17l5.5 3H21c.6 0 1-.4 1-1v-1c0-.3 0-.8-.5-1.5C20 14.5 16.5 13 12 13z"/></svg><span class="name">Libby</span></a></div>
 <div class="bookmark-item" data-category="news" data-ctx="personal"><a class="main-link" data-app-url="com.economist.lamarr://home" href="https://www.economist.com/"><svg aria-hidden="true" class="ctx-icon" fill="currentColor" stroke="none" viewBox="38 -714 543 714"><g transform="scale(1,-1)"><path d="M38 0V42H51Q84 42 108.5 53.5Q133 65 133 109V600Q133 647 109.0 659.5Q85 672 51 672H38V714H542L547 539H495L490 582Q486 615 466.5 639.5Q447 664 402 664H234V398H475V349H234V50H427Q474 50 495.5 74.5Q517 99 522 132L529 175H581L574 0Z"/></g></svg><span class="name">The Economist</span></a></div>
 <div class="bookmark-item" data-category="news" data-ctx="personal"><a class="main-link" data-app-url="twitter://timeline" href="https://x.com/home"><svg aria-hidden="true" class="ctx-icon" fill="currentColor" stroke="none" viewBox="0 0 24 24"><path d="M14.234 10.162 22.977 0h-2.072l-7.591 8.824L7.251 0H.258l9.168 13.343L.258 24H2.33l8.016-9.318L16.749 24h6.993zm-2.837 3.299-.929-1.329L3.076 1.56h3.182l5.965 8.532.929 1.329 7.754 11.09h-3.182z"></path></svg><span class="name">X</span></a></div>
-<div class="bookmark-item" data-category="games" data-ctx="personal"><a class="main-link" data-app-url="games://" href="https://store.steampowered.com/"><svg aria-hidden="true" class="ctx-icon" fill="currentColor" stroke="none" viewBox="0 0 24 24"><circle cx="12" cy="12" r="11"/><circle cx="8.5" cy="9" r="2" fill="var(--cat-games)"/><circle cx="15" cy="7" r="2" fill="var(--cat-games)"/><path d="M5.5 13 Q8 20 14 19 Q19 18.5 19.5 14 Q20 11 17 12 Q12 13.5 5.5 13Z" fill="var(--cat-games)"/></svg><span class="name">Games</span></a></div>
+<div class="bookmark-item" data-category="news" data-ctx="personal"><a class="main-link" data-app-url="nytimes://" href="https://www.nytimes.com/"><svg aria-hidden="true" class="ctx-icon" fill="currentColor" stroke="none" viewBox="0 0 24 24"><path d="M4 3h16l.35 5.25h-1.8c-.18-1.25-.58-2.15-1.2-2.7-.62-.55-1.55-.83-2.8-.83H13.3v13.05c0 .72.18 1.2.53 1.45.35.25.98.37 1.87.37h.55V21h-8.5v-1.41h.55c.89 0 1.52-.12 1.87-.37.35-.25.53-.73.53-1.45V4.72H9.45c-1.25 0-2.18.28-2.8.83-.62.55-1.02 1.45-1.2 2.7h-1.8L4 3Z"/></svg><span class="name">NYTimes</span></a><a class="access-link" href="https://libwww.freelibrary.org/elecres/NYTimesRemote.cfm" aria-label="Access The New York Times through the Free Library">Access</a></div>
 <div class="no-results" id="no-results">No bookmarks match your search.</div>
 </div>
 </div>

--- a/shared.css
+++ b/shared.css
@@ -174,6 +174,7 @@ header {
 }
 
 .bookmark-item {
+  position: relative;
   border-radius: 0; /* Windows Phone style */
   transition: filter 0.15s, transform 0.1s;
   display: flex;
@@ -207,6 +208,27 @@ header {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.bookmark-item > a.access-link {
+  position: absolute;
+  top: 0.35rem;
+  right: 0.35rem;
+  z-index: 2;
+  padding: 0.15rem 0.35rem;
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  background: rgba(0, 0, 0, 0.18);
+  color: #ffffff !important;
+  text-decoration: none;
+  font-size: 0.58rem;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.bookmark-item > a.access-link:hover {
+  background: rgba(255, 255, 255, 0.24);
 }
 
 /* Icons inside the tile */


### PR DESCRIPTION
Replaces the Games bookmark with a NYTimes news card. Adds the nytimes:// app URL, the https://www.nytimes.com/ web fallback, a small Free Library access link inside the card, a NYTimes-style SVG icon, and styling for the access link.