### PR TITLE
Make browser tiles grey

### DIFF
--- a/browsers.html
+++ b/browsers.html
@@ -13,6 +13,13 @@
 <meta content="Browsers" name="apple-mobile-web-app-title"/>
 <meta content="#000000" name="theme-color"/>
 <link rel="stylesheet" href="shared.css?v=5">
+<style>
+  .bookmark-item[data-category="safari"],
+  .bookmark-item[data-category="vpn"],
+  .bookmark-item[data-category="orion"] {
+    background: #555555;
+  }
+</style>
 <script>
   window.APP_CATEGORY_ORDER = ['safari', 'vpn', 'orion'];
   window.APP_CUSTOM_ORDER = {


### PR DESCRIPTION
Adds page-scoped CSS in browsers.html so the Safari, Proton VPN, and Orion tiles all use the same grey background.