### PR TITLE
Make bookmarks health tiles red

### DIFF
--- a/bookmarks.html
+++ b/bookmarks.html
@@ -24,6 +24,10 @@
     'health': ['oura ring', 'clublocker', 'solidcore']
   };
 </script>
+<style>
+  /* Page-scoped health category color: classic Windows Phone red */
+  .bookmark-item[data-category="health"] { background: #E51400; }
+</style>
 </head>
 <body>
 <svg aria-hidden="true" focusable="false" style="position:absolute;width:0;height:0;overflow:hidden">


### PR DESCRIPTION
## Summary\n- Add a page-scoped bookmarks.html override for the health category\n- Use classic Windows Phone red (#E51400) so the health tiles fit the existing tile palette\n- Leave shared.css unchanged, so no stylesheet cache version bump is needed\n\n## Testing\n- Verified only bookmarks.html changed\n- Ran git diff --check