### PR TITLE
Update bookmarks category colors

### DIFF
--- a/bookmarks.html
+++ b/bookmarks.html
@@ -25,8 +25,10 @@
   };
 </script>
 <style>
-  /* Page-scoped health category color: classic Windows Phone red */
-  .bookmark-item[data-category="health"] { background: #E51400; }
+  /* Page-scoped bookmarks category colors, inspired by leading apps in each group */
+  .bookmark-item[data-category="listen"] { background: #1DB954; } /* Spotify green */
+  .bookmark-item[data-category="news"] { background: #E3120B; } /* Economist red */
+  .bookmark-item[data-category="health"] { background: #2664F5; } /* Solidcore-inspired blue */
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary\n- Set listening tiles to Spotify green (#1DB954)\n- Set news tiles to Economist red (#E3120B)\n- Set health tiles to a Solidcore-inspired blue (#2664F5)\n- Keep the changes page-scoped in bookmarks.html so shared.css remains unchanged\n\n## Testing\n- Verified only bookmarks.html changed\n- Confirmed the three expected color overrides are present\n- Served the site locally and verified bookmarks.html, bookmarks.webmanifest, shared.css, and shared.js return successfully\n- Ran git diff --check