### PR TITLE
Add search router with multi-browser support for iOS

### DIFF
--- a/search.html
+++ b/search.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" name="viewport"/>
+<title>Search Router</title>
+<link href="/bookmarks-icon-180.png" rel="apple-touch-icon"/>
+<meta content="yes" name="apple-mobile-web-app-capable"/>
+<meta content="black-translucent" name="apple-mobile-web-app-status-bar-style"/>
+<meta content="Search" name="apple-mobile-web-app-title"/>
+<meta content="#000000" name="theme-color"/>
+<link rel="stylesheet" href="shared.css?v=9">
+<style>
+  .search-page-container {
+    justify-content: center;
+    padding-top: 10vh;
+  }
+  @media (max-width: 600px) {
+    .search-page-container {
+      padding-top: 5vh;
+    }
+  }
+</style>
+</head>
+<body>
+<div class="container search-page-container">
+<header>
+<div class="search-area">
+<div class="search-filter-unit">
+<div class="search-input-wrap">
+<svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+<input autocomplete="off" id="search" placeholder="Search the web..." type="text"/>
+</div>
+<div class="web-search-row">
+<button class="web-btn" data-engine="ddg"><svg fill="none" height="12" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="12"><circle cx="12" cy="12" r="10"></circle><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path></svg>DuckDuckGo</button>
+<button class="web-btn" data-engine="bing"><svg fill="none" height="12" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="12"><path d="M5 3l14 9-14 9V3z"></path></svg>Bing</button>
+<button class="web-btn" data-engine="google"><svg fill="none" height="12" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="12"><path d="M12 2a10 10 0 1 0 10 10H12V2z"></path><path d="M12 12L21 7.5"></path></svg>Google</button>
+</div>
+<div class="web-search-row">
+<button class="web-btn" data-engine="perplexity"><svg fill="none" height="12" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="12"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"></path></svg>Perplexity</button>
+<button class="web-btn" data-engine="grok"><svg fill="none" height="12" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="12"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle></svg>Grok</button>
+<button class="web-btn" data-engine="maps"><svg fill="none" height="12" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="12"><path d="M12 22s-8-4.5-8-11.8A8 8 0 0 1 12 2a8 8 0 0 1 8 8.2c0 7.3-8 11.8-8 11.8z"></path></svg>Maps</button>
+</div>
+<div class="browser-selector-row">
+<label class="browser-option">
+<input name="browser" type="radio" value="safari" checked/>
+<span>Safari</span>
+</label>
+<label class="browser-option">
+<input name="browser" type="radio" value="orion"/>
+<span>Orion</span>
+</label>
+<label class="browser-option">
+<input name="browser" type="radio" value="comet"/>
+<span>Comet</span>
+</label>
+</div>
+</div>
+</div>
+</header>
+</div>
+<script src="shared.js?v=2"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const searchInput = document.getElementById('search');
+    const urlParams = new URLSearchParams(window.location.search);
+    const query = urlParams.get('q');
+
+    if (query) {
+      searchInput.value = query;
+      // Optionally auto-trigger search if directed to do so, but user said "prepopulate"
+    }
+
+    // Restore browser preference
+    const savedBrowser = localStorage.getItem('preferred_browser');
+    if (savedBrowser) {
+      const radio = document.querySelector(`input[name="browser"][value="${savedBrowser}"]`);
+      if (radio) radio.checked = true;
+    }
+
+    // Save browser preference on change
+    document.querySelectorAll('input[name="browser"]').forEach(radio => {
+      radio.addEventListener('change', (e) => {
+        localStorage.setItem('preferred_browser', e.target.value);
+      });
+    });
+  });
+</script>
+</body>
+</html>

--- a/shared.css
+++ b/shared.css
@@ -86,6 +86,25 @@ header {
   position: relative;
 }
 
+#clear-search {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 5px;
+  display: none;
+}
+
+#clear-search:hover {
+  color: var(--text);
+}
+
 .search-input-wrap svg {
   position: absolute;
   left: 14px;
@@ -113,6 +132,40 @@ header {
 .web-search-row {
   display: flex;
   border-top: 1px solid var(--border);
+}
+
+.browser-selector-row {
+  display: flex;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.browser-option {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 0;
+  cursor: pointer;
+  transition: all 0.15s;
+  border-right: 1px solid var(--border);
+  gap: 0.3rem;
+}
+
+.browser-option:last-child {
+  border-right: none;
+}
+
+.browser-option input {
+  display: none;
+}
+
+.browser-option:has(input:checked) {
+  background: var(--accent-dim);
+  color: var(--accent);
+  font-weight: 600;
 }
 
 .web-btn {

--- a/shared.js
+++ b/shared.js
@@ -50,13 +50,36 @@ document.addEventListener('DOMContentLoaded', () => {
       if (searchMatch) anyVisible = true;
     });
 
-    noResults.classList.toggle('visible', !anyVisible);
+    if (noResults) noResults.classList.toggle('visible', !anyVisible);
   }
-
-  search.addEventListener('input', applyFilters);
 
   // Focus management
   if (!('ontouchstart' in window)) search.focus();
+
+  // Clear button logic
+  const clearBtn = document.createElement('button');
+  clearBtn.id = 'clear-search';
+  clearBtn.innerHTML = '&times;';
+  clearBtn.setAttribute('aria-label', 'Clear search');
+  search.parentNode.appendChild(clearBtn);
+
+  function toggleClearBtn() {
+    clearBtn.style.display = search.value ? 'block' : 'none';
+  }
+
+  search.addEventListener('input', () => {
+    toggleClearBtn();
+    applyFilters();
+  });
+
+  clearBtn.addEventListener('click', () => {
+    search.value = '';
+    search.focus();
+    toggleClearBtn();
+    applyFilters();
+  });
+
+  toggleClearBtn();
 
   document.addEventListener('keydown', e => {
     if (e.key === '/' && document.activeElement !== search) {
@@ -70,12 +93,17 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  // Enter key triggers DDG web search
+  // Enter key triggers default web search
   search.addEventListener('keydown', e => {
     if (e.key === 'Enter') {
       e.preventDefault();
       const q = search.value.trim();
-      if (q) doSearch('ddg-html');
+      if (q) {
+        const browser = document.querySelector('input[name="browser"]:checked')?.value || 'safari';
+        // bookmarks.html uses ddg-html by default, search.html uses ddg
+        const defaultEngine = document.body.contains(document.getElementById('grid')) ? 'ddg-html' : 'ddg';
+        window.doSearch(defaultEngine, browser);
+      }
     }
   });
 
@@ -113,43 +141,77 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // Web search function
-  function doSearch(engine) {
+  window.doSearch = function(engine, browser = 'safari') {
     const q = search.value.trim();
     if (!q) { search.focus(); return; }
     const enc = encodeURIComponent(q);
 
-    if (engine === 'maps' && /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)) {
-      var appUrl = /Android/i.test(navigator.userAgent)
-        ? 'geo:0,0?q=' + enc
-        : 'comgooglemaps://?q=' + enc;
-      var webUrl = 'https://maps.google.com/maps?q=' + enc;
+    const isIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent);
 
-      window.location.href = appUrl;
-      search.value = '';
-      applyFilters();
-      setTimeout(function() {
-        if (document.visibilityState !== 'hidden') {
-          window.open(webUrl, '_blank');
-        }
-      }, 1500);
-      return;
-    }
-
-    var urls = {
-      'ddg-html':    'https://html.duckduckgo.com/html/?q=' + enc,
+    const engines = {
+      'ddg':    'https://duckduckgo.com/?q=' + enc,
+      'ddg-html': 'https://html.duckduckgo.com/html/?q=' + enc,
+      'bing':   'https://www.bing.com/search?q=' + enc,
+      'google': 'https://www.google.com/search?q=' + enc,
       'bing-images': 'https://www.bing.com/images/search?q=' + enc,
       'maps':        'https://maps.google.com/maps?q=' + enc,
       'perplexity':  'https://www.perplexity.ai/search?q=' + enc,
       'grok':        'https://grok.com/?q=' + enc
     };
-    window.open(urls[engine], '_blank');
-    search.value = '';
-    applyFilters();
+
+    let url = engines[engine] || engines['ddg'];
+
+    if (isIOS) {
+      if (browser === 'orion') {
+        // Use browser's native search for default engine, otherwise open engine URL
+        if (engine === 'ddg' || engine === 'ddg-html') {
+          window.location.href = 'orion://search?q=' + enc;
+        } else {
+          window.location.href = 'orion://open-url?url=' + encodeURIComponent(url);
+        }
+        return;
+      } else if (browser === 'comet') {
+        if (engine === 'ddg' || engine === 'ddg-html') {
+          window.location.href = 'comet-ai://search?q=' + enc;
+        } else {
+          window.location.href = 'comet-ai://open-url?url=' + encodeURIComponent(url);
+        }
+        return;
+      }
     }
 
-    // Bind Web search buttons
-    document.querySelectorAll('.web-btn').forEach(btn => {
-    btn.addEventListener('click', () => doSearch(btn.dataset.engine));
+    // Special handling for maps app
+    if (engine === 'maps' && isIOS) {
+      const appUrl = /Android/i.test(navigator.userAgent)
+        ? 'geo:0,0?q=' + enc
+        : 'comgooglemaps://?q=' + enc;
+      
+      window.location.href = appUrl;
+      if (typeof applyFilters === 'function') {
+        search.value = '';
+        applyFilters();
+      }
+      setTimeout(function() {
+        if (document.visibilityState !== 'hidden') {
+          window.open(url, '_blank');
+        }
+      }, 1500);
+      return;
+    }
+
+    window.open(url, '_blank');
+    if (typeof applyFilters === 'function') {
+      search.value = '';
+      applyFilters();
+    }
+  }
+
+  // Bind Web search buttons
+  document.querySelectorAll('.web-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const browser = document.querySelector('input[name="browser"]:checked')?.value || 'safari';
+      window.doSearch(btn.dataset.engine, browser);
     });
+  });
 
 });


### PR DESCRIPTION
This PR adds a new search.html page that acts as a search router for iOS. It supports prepopulating the search box via URL parameters, selecting between different search engines, and choosing the target browser (Safari, Orion, or Comet). Shared logic has been consolidated in shared.js and shared.css.