### PR TITLE
Update resume for Elcano agent infrastructure

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -399,11 +399,11 @@
             <div class="contact-info">
                 <div class="contact-row">
                     <span class="contact-item"><span class="contact-emoji">📧</span><a href="mailto:brad@bradflaugher.com">brad@bradflaugher.com</a></span>
-                    <span class="contact-item"><span class="contact-emoji">💬</span><a href="https://signal.me/#eu/nNIgURzLjfztPIa7FoBO-5VicvmfitBN9JQjUuBQLBWEqjESWEBCQpuF8wriPmS7" target="_blank">Signal: bradflaugher.99</a></span>
+                    <span class="contact-item"><span class="contact-emoji">🌐</span><a href="https://bradflaugher.com" target="_blank">bradflaugher.com</a></span>
                 </div>
                 <div class="contact-row">
-                    <span class="contact-item"><span class="contact-emoji">🌐</span><a href="https://bradflaugher.com" target="_blank">bradflaugher.com</a></span>
                     <span class="contact-item"><span class="contact-emoji">💻</span><a href="https://github.com/bradflaugher" target="_blank">github.com/bradflaugher</a></span>
+                    <span class="contact-item"><span class="contact-emoji">𝕏</span><a href="https://x.com/BradFlaugher" target="_blank">x.com/BradFlaugher</a></span>
                 </div>
             </div>
         </header>
@@ -426,9 +426,9 @@
         <section class="section">
           <h2>Professional Summary</h2>
           <p>
-            I operate as a high-impact advisor and hands-on builder, helping organizations navigate pivotal moments and ship what matters. 
-            With a multi-disciplinary toolkit spanning code, data, commerce, economic insight, and historical context, I architect and integrate robust systems that unlock growth. 
-            No fluff, just focused problem-solving, fast iteration, and a commitment to tangible results alongside your team.
+            I operate as a high-impact advisor and hands-on builder for AI-native products, agent harness design and implementation, and secure platform architecture. 
+            With a multi-disciplinary toolkit spanning code, data, commerce, economic insight, and historical context, I design composable systems that move from strategy to production quickly. 
+            No fluff: focused problem-solving, fast iteration, and durable execution with teams that need results.
           </p>
         </section>
         
@@ -472,10 +472,10 @@
               </div>
               <div class="responsibilities">
                 <ul>
-                  <li>Leading technology strategy and execution for a pioneering supply-side curation platform that simplifies the complex programmatic advertising ecosystem, enabling partners to navigate and lead the digital media landscape.</li>
-                  <li>Building an AI agent platform that autonomously executes complex analytical and operational tasks—from natural-language data queries to campaign optimization—across hybrid cloud and on-premises infrastructure, with centralized orchestration, real-time monitoring, and fully ephemeral containerized execution for security and scalability.</li>
-                  <li>Architecting platform-agnostic solutions that integrate seamlessly across SSPs, DSPs, and data platforms, delivering end-to-end curated programmatic execution from deal strategy through activation and optimization for advertisers, publishers, agencies, and data providers.</li>
-                  <li>Driving innovation in AI-powered campaign optimization and data-driven curation to address bloated supply paths, performance challenges, and fragmented workflows in the adtech ecosystem. Visit <a href="https://www.elcanotek.com" target="_blank">elcanotek.com</a> to learn more.</li>
+                  <li>Set technology strategy and shipped agentic infrastructure for supply-side curation, translating programmatic advertising workflows into autonomous, auditable systems for deal analysis, reporting, activation, and optimization.</li>
+                  <li>Built the Victoria agent stack: Go-based orchestration, pull-based task runners, ephemeral Podman execution, one-shot and multi-turn agent runtimes, MCP tool integrations, and persistent execution history designed to minimize inbound attack surface.</li>
+                  <li>Standardized a composable, multi-modal architecture that decouples persona, prompts, protocols, and skills from runtime targets across Elcano infrastructure, chat, voice, and virtual API deployments.</li>
+                  <li>Led agent harness design and implementation engagements for publicly traded ad-tech companies, including platform-agnostic integrations across SSPs, data warehouses, email/reporting pipelines, and browser-only vendor workflows. Visit <a href="https://www.elcanotek.com" target="_blank">elcanotek.com</a> to learn more.</li>
                 </ul>
               </div>
             </div>
@@ -487,9 +487,9 @@
                 </div>
                 <div class="responsibilities">
                     <ul>
-                        <li>Negotiated Bread Factory merger (2018) and became CTO for the combined firm.</li>
-                        <li>Integrated 100-person engineering organization; scaled to 240 engineers across global locations (North America, Europe, Latin America, Asia), developing technical talent through structured <a href="https://inoxoft.com/blog/innovative-machine-learning-projects-in-python-from-inoxoft-students/" target="_blank">ML bootcamp programs</a>.</li>
-                        <li>Demonstrated versatility by serving diverse client portfolio - from enterprise clients like Procter & Gamble (optimizing advertising pipelines with 40 % BigQuery cost reduction) to startups like ReFuelrs (full design and deployment of on-demand fuel delivery app, <a href="https://inoxoft.com/casestudy/an-on-demand-delivery-app-of-essential-home-fuels/" target="_blank">Case Study</a>).</li>
+                        <li>Negotiated Bread Factory merger and became CTO for the combined firm.</li>
+                        <li>Integrated a 100-person engineering organization and scaled to 240 engineers across North America, Europe, Latin America, and Asia, including structured <a href="https://inoxoft.com/blog/innovative-machine-learning-projects-in-python-from-inoxoft-students/" target="_blank">ML bootcamp programs</a>.</li>
+                        <li>Served enterprise and startup clients, including Procter & Gamble advertising pipeline optimization with 40 % BigQuery cost reduction and ReFuelrs on-demand fuel delivery product design (<a href="https://inoxoft.com/casestudy/an-on-demand-delivery-app-of-essential-home-fuels/" target="_blank">Case Study</a>).</li>
                     </ul>
                 </div>
             </div>
@@ -570,23 +570,23 @@
                 <h2>Skills</h2>
                 <div class="skills-matrix">
                     <div>
-                        <h3>Strategic Cost Optimization</h3>
-                        <p>HR/IT operations analysis • domestic vs. outsourced talent strategy • AI and automation for process efficiency • Agile methods for rapid value delivery</p>
+                        <h3>Agent Harness Design & Implementation</h3>
+                        <p>End-to-end agent harness implementation • agent loop design • MCP and skill systems • human review patterns • rapid production prototyping</p>
                     </div>
         
                     <div>
-                        <h3>Software & Platform Architecture</h3>
-                        <p>Long-term maintainability design • cost-minimized tech stack selection • maximizing software longevity • system resilience & security hardening • rapid prototyping & MVP development</p>
+                        <h3>Secure Platform Architecture</h3>
+                        <p>Composable microservices • rootless containers • pull-based runners • least-privilege deployment • system resilience and hardening</p>
                     </div>
         
                     <div>
-                        <h3>Product & Market Strategy</h3>
-                        <p>Product-market fit validation • market testing & analysis • strategic pricing models • innovation engineering frameworks</p>
+                        <h3>AI Systems & Data Integration</h3>
+                        <p>Multi-model orchestration • OpenAI-compatible providers • SSP and warehouse integrations • virtual APIs • automated reporting pipelines</p>
                     </div>
         
                     <div>
-                        <h3>Digital Transformation & Change</h3>
-                        <p>Digital transformation roadmaps for SMEs • change management implementation • fostering a culture of innovation • technology adoption strategies</p>
+                        <h3>Product & Innovation Strategy</h3>
+                        <p>Product-market fit validation • market testing and analysis • AI adoption strategy • cost-minimized build/buy decisions • executive advising</p>
                     </div>
                 </div>
             </section>
@@ -599,9 +599,8 @@
             <div class="responsibilities">
                 <ul>
                     <li>Published <a href="https://a.co/d/2BAlait" target="_blank"><em>AI Harmony</em></a> (2023), endorsed by leaders from YouTube, Wharton School, and Silver Lake.</li>
-                    <li>Founded and host the <a href="https://innovationphilly.com" target="_blank">Philadelphia Open Innovation Tournament</a>, an AI sprint connecting founders with top investors and accelerators in the region, and founder of the <a href="https://www.meetup.com/philly-data-and-ai" target="_blank">Philly Data & AI Meetup</a>, with over 2,000 members.</li>
-                    <li>Member, <a href="https://ai-analytics.wharton.upenn.edu/" target="_blank">Wharton AI & Analytics Initiative</a>: Engages with cutting-edge research, events, and insights, connecting with industry professionals and Wharton faculty to explore business applications of AI and analytics, contribute to thought leadership, and stay ahead of emerging trends.</li>
-                    <li>Lifetime member, <a href="https://member.acm.org/~flaugherb" target="_blank">ACM</a>.</li>
+                    <li>Maintain public agent infrastructure repos including <a href="https://github.com/bradflaugher/LFG" target="_blank">LFG</a> (Go terminal agent with rootless Podman task sandboxes), <a href="https://github.com/bradflaugher/LFA" target="_blank">LFA</a> (scheduled automation dashboard), <a href="https://github.com/bradflaugher/LFE" target="_blank">LFE</a> (privacy-first Android agent), and <a href="https://github.com/bradflaugher/box" target="_blank">box</a> (Fedora agent runtime image).</li>
+                    <li>Member, <a href="https://ai-analytics.wharton.upenn.edu/" target="_blank">Wharton AI & Analytics Initiative</a>, and lifetime member, <a href="https://member.acm.org/~flaugherb" target="_blank">ACM</a>.</li>
                 </ul>
             </div>
         </section>


### PR DESCRIPTION
## Summary\n- Update existing resume.html with Elcano agent infrastructure and architecture language\n- Refresh skills around agent harness design, secure platform architecture, AI systems, and product strategy\n- Replace Signal with X, remove Philadelphia Open Innovation Tournament / meetup content, consolidate Wharton AI and ACM, and add public agent infrastructure repos\n\n## Verification\n- Regenerated and visually reviewed a two-page PDF preview\n- Confirmed the top email, website, GitHub, and X links are clickable in the generated PDF\n- Confirmed Custom GPT and Manus references are absent from the generated PDF