### PR TITLE
Simplify coffee cup sizing and placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,14 +275,16 @@
     .desk {
       position: relative;
       z-index: 1;
-      --saucer: clamp(82px, 13vw, 96px);
-      padding: 0 calc(var(--saucer) * 0.42) calc(var(--saucer) * 0.5) 0;
+      --card-w: min(94vw, 580px);
+      --cup: calc(var(--card-w) * 0.26);
+      --cup-gap: max(14px, calc(var(--card-w) * 0.04));
+      width: var(--card-w);
+      padding-bottom: calc(var(--cup) + var(--cup-gap));
     }
 
     .card {
       position: relative;
-      width: 94vw;
-      max-width: 580px;
+      width: 100%;
       aspect-ratio: 1.75 / 1;
       /* Bone color - warm ivory with slight yellow undertone */
       background: linear-gradient(
@@ -464,24 +466,24 @@
 
     .coffee-link {
       position: absolute;
-      bottom: calc(var(--saucer) * 0.04);
-      left: 60%;
+      top: calc(100% + var(--cup-gap));
+      left: calc(50% + var(--card-w) * 0.1);
       display: block;
       text-decoration: none;
-      transform: rotate(4deg);
+      transform: rotate(3deg);
       transition: transform 0.4s ease, filter 0.4s ease;
-      filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.4));
+      filter: drop-shadow(0 6px 14px rgba(0, 0, 0, 0.38));
     }
 
     .coffee-link::before {
       content: '';
       position: absolute;
-      inset: calc(var(--saucer) * 0.14) calc(var(--saucer) * -0.06) calc(var(--saucer) * -0.08);
+      inset: 12% -6% -14%;
       border-radius: 50%;
       background: radial-gradient(
-        ellipse 88% 52% at 48% 58%,
-        rgba(0, 0, 0, 0.48) 0%,
-        rgba(0, 0, 0, 0.16) 46%,
+        ellipse 86% 50% at 48% 55%,
+        rgba(0, 0, 0, 0.42) 0%,
+        rgba(0, 0, 0, 0.14) 48%,
         transparent 74%
       );
       z-index: -1;
@@ -489,8 +491,8 @@
     }
 
     .coffee-link:hover {
-      transform: rotate(4deg) translateY(-3px) scale(1.03);
-      filter: drop-shadow(0 14px 28px rgba(0, 0, 0, 0.5));
+      transform: rotate(3deg) translateY(-3px) scale(1.03);
+      filter: drop-shadow(0 12px 24px rgba(0, 0, 0, 0.48));
     }
 
     .coffee-link:focus-visible {
@@ -501,61 +503,14 @@
 
     .coffee-top {
       position: relative;
-      width: var(--saucer);
-      height: var(--saucer);
-    }
-
-    .saucer {
-      position: absolute;
-      inset: 0;
-      border-radius: 50%;
-      background:
-        radial-gradient(
-          circle at 38% 32%,
-          #f2eadf 0%,
-          #e8e0d4 38%,
-          #d8d0c4 72%,
-          #cbc3b7 100%
-        );
-      box-shadow:
-        inset 0 2px 6px rgba(255, 255, 255, 0.65),
-        inset 0 -3px 8px rgba(0, 0, 0, 0.1),
-        0 3px 10px rgba(0, 0, 0, 0.28);
-    }
-
-    .saucer::before {
-      content: '';
-      position: absolute;
-      inset: calc(var(--saucer) * 0.13);
-      border-radius: 50%;
-      border: 1px solid rgba(0, 0, 0, 0.04);
-      box-shadow: inset 0 1px 3px rgba(255, 255, 255, 0.35);
-    }
-
-    .saucer::after {
-      content: '';
-      position: absolute;
-      top: calc(var(--saucer) * 0.09);
-      left: calc(var(--saucer) * 0.16);
-      width: calc(var(--saucer) * 0.32);
-      height: calc(var(--saucer) * 0.13);
-      border-radius: 50%;
-      background: radial-gradient(
-        ellipse,
-        rgba(255, 255, 255, 0.45) 0%,
-        transparent 70%
-      );
-      transform: rotate(-18deg);
-      pointer-events: none;
+      width: var(--cup);
+      height: var(--cup);
     }
 
     .cup-rim {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      width: calc(var(--saucer) * 0.56);
-      height: calc(var(--saucer) * 0.56);
-      transform: translate(-50%, -50%);
+      position: relative;
+      width: 100%;
+      height: 100%;
       border-radius: 50%;
       background: linear-gradient(
         145deg,
@@ -564,7 +519,7 @@
         #d4ccc0 100%
       );
       box-shadow:
-        0 0 0 calc(var(--saucer) * 0.058) #ebe3d7,
+        0 0 0 calc(var(--cup) * 0.07) #ebe3d7,
         inset 0 3px 10px rgba(0, 0, 0, 0.22),
         inset 0 -2px 4px rgba(255, 255, 255, 0.25),
         0 2px 6px rgba(0, 0, 0, 0.2);
@@ -573,7 +528,7 @@
     .cup-rim::before {
       content: '';
       position: absolute;
-      inset: 3px;
+      inset: 4%;
       border-radius: 50%;
       box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.35);
       pointer-events: none;
@@ -596,48 +551,9 @@
       pointer-events: none;
     }
 
-    .handle {
-      position: absolute;
-      top: 30%;
-      right: calc(var(--saucer) * -0.1);
-      width: calc(var(--saucer) * 0.34);
-      height: calc(var(--saucer) * 0.24);
-      transform: rotate(34deg);
-      pointer-events: none;
-    }
-
-    .handle::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      border: calc(var(--saucer) * 0.042) solid #d8d0c4;
-      border-radius: 50%;
-      border-top-color: transparent;
-      border-left-color: transparent;
-      box-shadow:
-        inset -1px 1px 2px rgba(255, 255, 255, 0.55),
-        1px 2px 5px rgba(0, 0, 0, 0.18);
-    }
-
-    .handle::after {
-      content: '';
-      position: absolute;
-      top: 18%;
-      left: 18%;
-      width: 58%;
-      height: 56%;
-      border-radius: 50%;
-      background: radial-gradient(
-        ellipse at 38% 42%,
-        rgba(30, 12, 6, 0.28) 0%,
-        rgba(18, 6, 2, 0.62) 100%
-      );
-      box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35);
-    }
-
     .coffee-surface {
       position: absolute;
-      inset: calc(var(--saucer) * 0.085);
+      inset: calc(var(--cup) * 0.11);
       border-radius: 50%;
       background:
         radial-gradient(
@@ -656,10 +572,10 @@
     .coffee-surface::before {
       content: '';
       position: absolute;
-      inset: 5px;
+      inset: 8%;
       border-radius: 50%;
-      border: 2px solid rgba(160, 110, 75, 0.35);
-      box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.25);
+      border: 1.5px solid rgba(160, 110, 75, 0.32);
+      box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.22);
       pointer-events: none;
     }
 
@@ -682,118 +598,24 @@
     .latte-art {
       position: relative;
       z-index: 1;
-      width: 52%;
-      height: 52%;
+      width: 58%;
+      height: 58%;
       transition: filter 0.35s ease;
+      overflow: visible;
     }
 
-    .latte-art::before {
-      content: '';
-      position: absolute;
-      inset: -12%;
-      border-radius: 50%;
-      background: radial-gradient(
-        circle,
-        rgba(255, 248, 238, 0.14) 0%,
-        transparent 68%
-      );
-      filter: blur(1px);
-      pointer-events: none;
-    }
-
-    .x-foam {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      width: 76%;
-      height: 27%;
-      margin: -13.5% 0 0 -38%;
-      border-radius: 999px;
-      background:
-        radial-gradient(
-          ellipse 80% 120% at 28% 42%,
-          rgba(255, 252, 246, 0.95) 0%,
-          rgba(245, 234, 216, 0.9) 45%,
-          rgba(232, 216, 194, 0.82) 100%
-        );
-      box-shadow:
-        0 0 1px rgba(255, 252, 246, 0.9),
-        0 0 6px rgba(242, 228, 208, 0.45),
-        0 0 12px rgba(242, 228, 208, 0.2),
-        inset 0 1px 2px rgba(255, 255, 255, 0.85),
-        inset 0 -1px 2px rgba(160, 120, 85, 0.15),
-        -3px 1px 0 rgba(255, 252, 246, 0.35),
-        3px -1px 0 rgba(255, 252, 246, 0.3),
-        0 3px 0 rgba(255, 252, 246, 0.25),
-        0 -3px 0 rgba(255, 252, 246, 0.2);
-      filter: blur(0.35px);
-    }
-
-    .x-foam-a {
-      transform: rotate(45deg);
-    }
-
-    .x-foam-b {
-      transform: rotate(-45deg);
-    }
-
-    .x-foam-a::before,
-    .x-foam-b::before {
-      content: '';
-      position: absolute;
-      width: 18%;
-      height: 55%;
-      border-radius: 50%;
-      background: radial-gradient(
-        circle,
-        rgba(255, 252, 246, 0.7) 0%,
-        transparent 72%
-      );
-      filter: blur(0.5px);
-    }
-
-    .x-foam-a::before {
-      top: 8%;
-      left: 12%;
-    }
-
-    .x-foam-b::before {
-      bottom: 10%;
-      right: 14%;
-    }
-
-    .x-foam-a::after,
-    .x-foam-b::after {
-      content: '';
-      position: absolute;
-      width: 12%;
-      height: 40%;
-      border-radius: 50%;
-      background: radial-gradient(
-        circle,
-        rgba(255, 252, 246, 0.55) 0%,
-        transparent 70%
-      );
-      filter: blur(0.4px);
-    }
-
-    .x-foam-a::after {
-      bottom: 18%;
-      right: 20%;
-    }
-
-    .x-foam-b::after {
-      top: 16%;
-      left: 18%;
+    .x-bar {
+      fill: url(#x-foam-fill);
+      filter: url(#x-foam-soft);
     }
 
     .coffee-link:hover .latte-art {
-      filter: brightness(1.1) saturate(1.05);
+      filter: brightness(1.08) saturate(1.04);
     }
 
     .steam {
       position: absolute;
-      inset: calc(var(--saucer) * 0.14);
+      inset: 10%;
       border-radius: 50%;
       pointer-events: none;
       overflow: visible;
@@ -812,26 +634,26 @@
     }
 
     .steam span:nth-child(1) {
-      width: calc(var(--saucer) * 0.24);
-      height: calc(var(--saucer) * 0.15);
-      top: calc(var(--saucer) * 0.06);
-      left: calc(var(--saucer) * 0.18);
+      width: 26%;
+      height: 16%;
+      top: 2%;
+      left: 16%;
       animation-delay: 0s;
     }
 
     .steam span:nth-child(2) {
-      width: calc(var(--saucer) * 0.19);
-      height: calc(var(--saucer) * 0.12);
-      top: calc(var(--saucer) * 0.03);
-      right: calc(var(--saucer) * 0.16);
+      width: 20%;
+      height: 13%;
+      top: 0;
+      right: 14%;
       animation-delay: 1.4s;
     }
 
     .steam span:nth-child(3) {
-      width: calc(var(--saucer) * 0.17);
-      height: calc(var(--saucer) * 0.11);
-      top: calc(var(--saucer) * 0.11);
-      left: calc(var(--saucer) * 0.32);
+      width: 18%;
+      height: 11%;
+      top: 8%;
+      left: 34%;
       animation-delay: 2.8s;
     }
 
@@ -899,16 +721,28 @@
       aria-label="Follow Brad Flaugher on X"
     >
       <div class="coffee-top" aria-hidden="true">
-        <div class="saucer"></div>
         <div class="cup-rim">
           <div class="coffee-surface">
-            <span class="latte-art">
-            <span class="x-foam x-foam-a"></span>
-            <span class="x-foam x-foam-b"></span>
-          </span>
+            <svg class="latte-art" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <defs>
+                <linearGradient id="x-foam-fill" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stop-color="#fffdf8"/>
+                  <stop offset="45%" stop-color="#f7ebda"/>
+                  <stop offset="100%" stop-color="#e6d4bc"/>
+                </linearGradient>
+                <filter id="x-foam-soft" x="-30%" y="-30%" width="160%" height="160%">
+                  <feGaussianBlur in="SourceGraphic" stdDeviation="0.35" result="blur"/>
+                  <feMerge>
+                    <feMergeNode in="blur"/>
+                    <feMergeNode in="SourceGraphic"/>
+                  </feMerge>
+                </filter>
+              </defs>
+              <rect class="x-bar" x="10.25" y="3.5" width="3.5" height="17" rx="1.75" transform="rotate(45 12 12)"/>
+              <rect class="x-bar" x="10.25" y="3.5" width="3.5" height="17" rx="1.75" transform="rotate(-45 12 12)"/>
+            </svg>
           </div>
         </div>
-        <div class="handle"></div>
         <div class="steam">
           <span></span>
           <span></span>


### PR DESCRIPTION
- Remove saucer and handle — overhead cup rim only
- Scale cup to 26% of card width (`--cup` tied to `--card-w`)
- Position cup entirely below the card with a gap — no overlap
- Offset right of center on the desk
- SVG foam X latte art with soft blur and cream gradient
- Still hidden on mobile (≤520px)