### PR TITLE
Add resume paper and GitHub sticky note easter eggs (desktop only)

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,9 +277,7 @@
       z-index: 1;
       --card-w: min(94vw, 580px);
       --cup: calc(var(--card-w) * 0.42);
-      --cup-gap: max(40px, calc(var(--card-w) * 0.1));
       width: var(--card-w);
-      padding-bottom: calc(var(--cup) * 1.18 + var(--cup-gap));
     }
 
     .card {
@@ -444,10 +442,10 @@
     }
 
     .coffee-link {
-      position: absolute;
-      top: calc(100% - var(--cup) * 1.18);
-      left: calc(50% + var(--card-w) * 0.04);
-      display: block;
+      display: none;
+      position: fixed;
+      right: clamp(36px, 5vw, 110px);
+      bottom: clamp(30px, 6vh, 96px);
       text-decoration: none;
       transform: rotate(3deg);
       filter: drop-shadow(0 6px 14px rgba(0, 0, 0, 0.38));
@@ -668,28 +666,124 @@
       }
     }
 
-    @media (max-width: 520px) {
-      .desk {
-        padding: 0;
-      }
-
-      .coffee-link {
-        display: none;
-      }
+    /* Resume: a sheet of paper pushed to the far corner of the desk */
+    .paper-link {
+      display: none;
+      position: fixed;
+      top: -74px;
+      left: -48px;
+      transform: rotate(-8deg);
+      text-decoration: none;
+      filter: drop-shadow(4px 6px 12px rgba(0, 0, 0, 0.4));
     }
 
-    /* Wide screens: card sits dead center, cup rests in the corner of the desk */
-    @media (min-width: 1200px) {
-      .desk {
-        padding-bottom: 0;
-      }
+    .paper-link:focus-visible {
+      outline: 2px solid rgba(240, 232, 220, 0.55);
+      outline-offset: 8px;
+    }
 
-      .coffee-link {
-        position: fixed;
-        top: auto;
-        left: auto;
-        right: clamp(36px, 5vw, 110px);
-        bottom: clamp(30px, 6vh, 96px);
+    .paper-sheet {
+      position: relative;
+      width: 212px;
+      height: 274px;
+      background: linear-gradient(
+        155deg,
+        #ece4d8 0%,
+        #f3ebde 45%,
+        #e8e0d3 100%
+      );
+      box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.05);
+      transition: filter 0.3s ease;
+    }
+
+    .paper-sheet::before {
+      content: '';
+      position: absolute;
+      top: 38%;
+      left: 16%;
+      width: 44%;
+      height: 7px;
+      background: rgba(26, 26, 26, 0.5);
+    }
+
+    .paper-sheet::after {
+      content: '';
+      position: absolute;
+      top: 48%;
+      left: 16%;
+      right: 15%;
+      bottom: 11%;
+      background: repeating-linear-gradient(
+        180deg,
+        rgba(26, 26, 26, 0.26) 0 2px,
+        transparent 2px 13px
+      );
+    }
+
+    .paper-link:hover .paper-sheet {
+      filter: brightness(1.05);
+    }
+
+    /* GitHub: a sticky note with an Octocat doodle */
+    .sticky-link {
+      display: none;
+      position: fixed;
+      bottom: clamp(26px, 5vh, 84px);
+      left: clamp(30px, 4vw, 96px);
+      transform: rotate(-5deg);
+      text-decoration: none;
+      filter: drop-shadow(2px 5px 9px rgba(0, 0, 0, 0.38));
+    }
+
+    .sticky-link:focus-visible {
+      outline: 2px solid rgba(240, 232, 220, 0.55);
+      outline-offset: 8px;
+    }
+
+    .sticky-note {
+      position: relative;
+      width: 118px;
+      height: 118px;
+      background: linear-gradient(
+        168deg,
+        #efe4ae 0%,
+        #e8da9d 62%,
+        #dccb89 100%
+      );
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .sticky-note::after {
+      content: '';
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      width: 0;
+      height: 0;
+      border-top: 16px solid rgba(74, 58, 24, 0.16);
+      border-right: 16px solid transparent;
+    }
+
+    .octocat {
+      width: 62%;
+      height: 62%;
+      fill: #4c4034;
+      opacity: 0.82;
+      transition: opacity 0.3s ease;
+    }
+
+    .sticky-link:hover .octocat {
+      opacity: 1;
+    }
+
+    /* Desk easter eggs are desktop-only; mobile keeps just the card */
+    @media (min-width: 1200px) {
+      .coffee-link,
+      .paper-link,
+      .sticky-link {
+        display: block;
       }
     }
 
@@ -765,6 +859,32 @@
           <span></span>
           <span></span>
         </div>
+      </div>
+    </a>
+    <a
+      href="/resume"
+      class="paper-link"
+      aria-label="View Brad Flaugher's resume"
+    >
+      <div class="paper-sheet" aria-hidden="true"></div>
+    </a>
+    <a
+      href="https://github.com/bradflaugher"
+      class="sticky-link"
+      target="_blank"
+      rel="noopener"
+      aria-label="Brad Flaugher on GitHub"
+    >
+      <div class="sticky-note" aria-hidden="true">
+        <svg class="octocat" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <filter id="ink-wobble" x="-20%" y="-20%" width="140%" height="140%">
+              <feTurbulence type="fractalNoise" baseFrequency="0.18" numOctaves="1" seed="4" result="noise"/>
+              <feDisplacementMap in="SourceGraphic" in2="noise" scale="0.5"/>
+            </filter>
+          </defs>
+          <path filter="url(#ink-wobble)" d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
+        </svg>
       </div>
     </a>
   </div>


### PR DESCRIPTION
## Summary
- **Resume** (`/resume`): an ivory paper sheet peeking in from the top-left corner, rotated slightly, with abstract letterhead + text lines — diagonally balances the mug
- **GitHub** (github.com/bradflaugher): a muted sticky note in the bottom-left with an Octocat doodle, ink edges wobbled via SVG turbulence for a hand-drawn look
- **Desktop-only easter eggs**: all three desk objects (coffee cup included) now render only at ≥1200px; tablets and phones get just the centered business card
- Layout simplified: the desk no longer reserves padding for the cup and the mid-width below-card cup layout is removed
- Hovers stay content-only (paper brightens, Octocat ink darkens, foam X brightens); accessible labels + focus outlines on all three links

## Test plan
- Playwright at 1440×860: all three objects visible, card centered, zero overflow
- 1000×900 and 420×800: all easter eggs hidden, card only, zero overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)