### PR TITLE
Consolidate Elcano section so the resume PDF fits on two pages

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -472,10 +472,8 @@
               </div>
               <div class="responsibilities">
                 <ul>
-                  <li>Set technology strategy and shipped agentic infrastructure for supply-side curation, translating programmatic advertising workflows into autonomous, auditable systems for deal analysis, reporting, activation, and optimization.</li>
-                  <li>Created and open-sourced <a href="https://github.com/ElcanoTek/fleet" target="_blank">fleet</a>, the agent platform behind Elcano's Victoria: one process boots a unified agent runtime, execution sandbox, scheduler, and worker pool, serving interactive chat, terminal, and scheduled-operations surfaces from the same governed core.</li>
+                  <li>Created and open-sourced <a href="https://github.com/ElcanoTek/fleet" target="_blank">fleet</a>, the model-agnostic agent platform behind Elcano's supply-side curation: one process boots a unified agent runtime, execution sandbox, scheduler, and worker pool, serving interactive chat, terminal, and scheduled-operations surfaces from the same governed core.</li>
                   <li>Designed fleet's trust model for governed, auditable delegation: every tool call — bash, Python, file I/O, MCP — executes in an ephemeral rootless-Podman sandbox with no fast path around it, every turn is metered against a cost ceiling, and credentials are brokered host-side so they never enter the sandbox.</li>
-                  <li>Kept agent IP portable by design — model-agnostic loop that picks the best model per task, with persona, prompts, protocols, and skills packaged as client-config bundles decoupled from runtime targets across chat, voice, and virtual API deployments.</li>
                   <li>Led agent harness design and implementation engagements for publicly traded ad-tech companies, including platform-agnostic integrations across SSPs, data warehouses, email/reporting pipelines, and browser-only vendor workflows. Visit <a href="https://www.elcanotek.com" target="_blank">elcanotek.com</a> to learn more.</li>
                 </ul>
               </div>


### PR DESCRIPTION
## Summary
- Remove the two bullets flagged (technology-strategy and agent-IP-portability), folding their load-bearing phrases — *supply-side curation* and *model-agnostic* — into the lead fleet bullet so nothing essential is lost
- Elcano section is now three bullets: fleet platform, fleet trust model, client engagements

## Test plan
- Ran `resume_converter.py` (same WeasyPrint pipeline the GitHub Action uses) locally: output is exactly **2 pages**

🤖 Generated with [Claude Code](https://claude.com/claude-code)